### PR TITLE
editor utilizando fonte padrao

### DIFF
--- a/components/exercise-code.tsx
+++ b/components/exercise-code.tsx
@@ -20,7 +20,7 @@ const ExerciseCodeContainer = styled.div`
 `
 
 const EditorContainer = styled.div`
-  border: 1px solid ${({theme}) => theme.colors.secondary};
+  border: 1px solid ${({theme}) => theme.colors.editorBorder};
   height: 65%;
 `
 
@@ -33,7 +33,7 @@ const SavedAtInfo = styled.p`
 
 const OutputContainer = styled.div`
   padding: ${({theme}) => theme.space[1]};
-  border: 1px solid ${({theme}) => theme.colors.secondary};
+  border: 1px solid ${({theme}) => theme.colors.editorBorder};
   border-top: 0px;
   border-bottom: 0px;
   height: 35%;
@@ -107,7 +107,7 @@ export const ExerciseCode = ({ onAutoSaveEvent, onChange, code, slug, lastSavedA
               automaticLayout: true,
               padding: {top: theme.space[3], bottom: theme.space[3]},
               scrollBeyondLastLine: false,
-              fontFamily: theme.fonts.code,
+              fontFamily: theme.fonts.codeEditor,
               fontSize: 16,
               tabSize: 2,
               quickSuggestions: {

--- a/components/exercise-details.tsx
+++ b/components/exercise-details.tsx
@@ -8,7 +8,7 @@ const ContentDetailsContainer = styled.div`
   overflow-y: auto;
 
   pre {
-    border: 1px solid ${({ theme }) => theme.colors.codeBlockBorder};
+    border: 1px solid ${({ theme }) => theme.colors.contentCodeBorder};
     color: ${({ theme }) => theme.colors.textDarkGray};
     padding: ${({theme}) => theme.space[2]};
     overflow: auto;
@@ -16,7 +16,7 @@ const ContentDetailsContainer = styled.div`
 `
 
 const ExerciseText = styled.div`
-    font-size: ${({theme}) => theme.fontSize.large};
+  font-size: ${({theme}) => theme.fontSize.large};
 `
 
 interface ContentDetailsProps {

--- a/components/page-container.tsx
+++ b/components/page-container.tsx
@@ -5,7 +5,7 @@ interface PageContainerProps {
 }
 
 const ContainerBasis = styled.div`
-  display: grid;
+  display: flex;
 
   height: ${({theme}) => theme.layout.contentSize};
 
@@ -15,7 +15,7 @@ const ContainerBasis = styled.div`
 `
 
 const TwoColumnsPage = styled(ContainerBasis)`
-  grid-template-columns: ${({theme}) => theme.layout.sidebarWidth} 1fr;
+  /* grid-template-columns: ${({theme}) => theme.layout.sidebarWidth} 1fr; */
 `
 
 export const PageContainer = ({ children }: PageContainerProps) => {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -3,7 +3,8 @@ import { DefaultTheme } from 'styled-components'
 export const theme: DefaultTheme = {
   fonts: {
     primary: 'Nunito',
-    code: '"Fira code", "Fira Mono", monospace'
+    code: '"Fira code", "Fira Mono"',
+    codeEditor: 'monospace'
   },
   fontSize: {
     xsmall: '0.75em',
@@ -27,7 +28,7 @@ export const theme: DefaultTheme = {
     text: '#444',
     textDarkGray: '#666',
     sectionSeparator: '#AAA',
-    codeBlockBorder: '#CCC',
+    editorBorder: '#CCC',
     white: '#DDD',
   },
   space: [

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -28,7 +28,8 @@ export const theme: DefaultTheme = {
     text: '#444',
     textDarkGray: '#666',
     sectionSeparator: '#AAA',
-    editorBorder: '#CCC',
+    editorBorder: '#ccd8ec',
+    contentCodeBorder: '#DFDFDF',
     white: '#DDD',
   },
   space: [

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -29,6 +29,7 @@ declare module 'styled-components' {
       text: string,
       textDarkGray: string,
       editorBorder: string,
+      contentCodeBorder: string,
       sectionSeparator: string,
       white: string
     },

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -4,7 +4,8 @@ declare module 'styled-components' {
   export interface DefaultTheme {
     fonts: {
         primary: string,
-        code: string
+        code: string,
+        codeEditor: string
     },
     fontSize: {
       xsmall: string,
@@ -27,7 +28,7 @@ declare module 'styled-components' {
       background: string,
       text: string,
       textDarkGray: string,
-      codeBlockBorder: string,
+      editorBorder: string,
       sectionSeparator: string,
       white: string
     },


### PR DESCRIPTION
- Editor utilizando fonte `monospace` padrão

Outros ajustes:
- Ajustada bordas do editor (alterado de azul escuro para azul claro)
- Ajustada borda de bloco de códigos do conteúdo (vindo do MD)
- Container do app layout com `flex` em vez de `grid`