### PR TITLE
Refatoração da Sidebar removendo biblioteca externa

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -6,9 +6,17 @@ export const Button = styled.button`
   border: 1px solid ${({theme}) => theme.colors.primary};
   color: white;
   font-size: ${({theme}) => theme.fontSize.large};
-  cursor: pointer;
+
+  svg {
+    position: relative;
+    top: -2px;
+    width: ${({theme}) => theme.fontSize.large};
+    height: ${({theme}) => theme.fontSize.large};
+    margin-right: ${({theme}) => theme.space[1]};
+  }
 
   &:hover {
+    cursor: pointer;
     background-color: ${({theme}) => theme.colors.primaryOpacity08};
   }
 `

--- a/components/exercise-code.tsx
+++ b/components/exercise-code.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import styled from "styled-components";
+import { useEffect, useState } from "react";
 import { useTheme } from 'styled-components'
 import Editor from "@monaco-editor/react";
 import { Play } from "@styled-icons/feather/Play";
@@ -75,60 +75,6 @@ export const ExerciseCode = ({ onAutoSaveEvent, onChange, code, slug, lastSavedA
     autosaveMilliseconds // Se for igual a 2000, a cada 2 segundos depois da última alteração no código
   );
 
-  const executeCode = () => {
-    try {
-      const wrapCode = (code: string): string[] => {
-        const prefixFnCode = "" +
-          "let w___logs = []; \n" + 
-          "function w___customLogFn(text){ \n" +
-          "  w___logs.push(String(text)); \n" +
-          "} \n";
-
-        const parsedCode = code.replace(
-          /console\.(log|info|debug|warn|error)/g, 
-          "w___customLogFn"
-        ) + "\n";
-
-        const suffixFnCode = `return w___logs`;
-        const finalCode = prefixFnCode + parsedCode + suffixFnCode;
-
-        return new Function(finalCode)();
-      }
-      setLogs(wrapCode(code));
-    } catch (error) {
-      let message = 'Erro desconhecido';
-      let stack;
-      if (error instanceof Error) {
-        message = error.message;
-        stack = error.stack?.toString();
-      } 
-      alert(`Ops, tem algo de errado com seu código: ${message}\n\nStackTrace:\n${stack}`);
-      setLogs([]);
-    }
-  }
-
-  const monacoEditorOptions = {
-    minimap: {enabled: false},
-    automaticLayout: true,
-    padding: {top: theme.space[3], bottom: theme.space[3]},
-    scrollBeyondLastLine: false,
-    fontFamily: theme.fonts.codeEditor,
-    fontSize: 16,
-    tabSize: 2,
-    quickSuggestions: {
-      other: false,
-      comments: false,
-      strings: false
-    },
-    parameterHints: {
-      enabled: false
-    },
-    suggestOnTriggerCharacters: false,
-    acceptSuggestionOnEnter: "off",
-    tabCompletion: "off",
-    wordBasedSuggestions: false,
-  }
-
   useEffect(() => {
     setLogs([])
   }, [code])
@@ -155,7 +101,29 @@ export const ExerciseCode = ({ onAutoSaveEvent, onChange, code, slug, lastSavedA
             onChange(value || '');
           }}
           theme="light"
-          options={monacoEditorOptions}
+          options={
+            {
+              minimap: {enabled: false},
+              automaticLayout: true,
+              padding: {top: theme.space[3], bottom: theme.space[3]},
+              scrollBeyondLastLine: false,
+              fontFamily: theme.fonts.codeEditor,
+              fontSize: 16,
+              tabSize: 2,
+              quickSuggestions: {
+                other: false,
+                comments: false,
+                strings: false
+              },
+              parameterHints: {
+                enabled: false
+              },
+              suggestOnTriggerCharacters: false,
+              acceptSuggestionOnEnter: "off",
+              tabCompletion: "off",
+              wordBasedSuggestions: false,
+            }
+          }
      
         />
       </EditorContainer>
@@ -167,7 +135,37 @@ export const ExerciseCode = ({ onAutoSaveEvent, onChange, code, slug, lastSavedA
           ))}
         </OutputText>
       </OutputContainer>
-      <FullWidthButton onClick={executeCode}>
+      <FullWidthButton onClick={() => {
+        try {
+          const wrapCode = (code: string): string[] => {
+            const prefixFnCode = "" +
+              "let w___logs = []; \n" + 
+              "function w___customLogFn(text){ \n" +
+              "  w___logs.push(String(text)); \n" +
+              "} \n";
+
+            const parsedCode = code.replace(
+              /console\.(log|info|debug|warn|error)/g, 
+              "w___customLogFn"
+            ) + "\n";
+
+            const suffixFnCode = `return w___logs`;
+            const finalCode = prefixFnCode + parsedCode + suffixFnCode;
+
+            return new Function(finalCode)();
+          }
+          setLogs(wrapCode(code));
+        } catch (error) {
+          let message = 'Erro desconhecido';
+          let stack;
+          if (error instanceof Error) {
+            message = error.message;
+            stack = error.stack?.toString();
+          } 
+          alert(`Ops, tem algo de errado com seu código: ${message}\n\nStackTrace:\n${stack}`);
+          setLogs([]);
+        }
+      }}>
         <Play size={theme.iconSize.medium}/> Executar Código
       </FullWidthButton>
     </ExerciseCodeContainer>

--- a/components/exercise-code.tsx
+++ b/components/exercise-code.tsx
@@ -1,12 +1,12 @@
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useTheme } from 'styled-components'
 import Editor from "@monaco-editor/react";
-
-import { FullWidthButton } from "./full-width-button";
-import { VscPlay } from "react-icons/vsc";
+import { Play } from "@styled-icons/feather/Play";
 import { useDebouncedCallback } from "use-debounce";
 import Moment from "react-moment";
-import { useEffect, useState } from "react";
+
+import { FullWidthButton } from "./full-width-button";
 
 const ExerciseCodeContainer = styled.div`
   padding: ${({theme}) => theme.space[4]} ${({theme}) => theme.space[4]};
@@ -166,7 +166,7 @@ export const ExerciseCode = ({ onAutoSaveEvent, onChange, code, slug, lastSavedA
           setLogs([]);
         }
       }}>
-        <VscPlay/> Executar Código
+        <Play size={theme.iconSize.medium}/> Executar Código
       </FullWidthButton>
     </ExerciseCodeContainer>
   )

--- a/components/full-width-button.tsx
+++ b/components/full-width-button.tsx
@@ -6,6 +6,17 @@ const ButtonContainer = styled.div`
 
   & > button {
     width: 100%;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      margin: auto 0;
+      width: ${({theme}) => theme.fontSize.xlarge};
+      height: ${({theme}) => theme.fontSize.xlarge};
+      margin-right: ${({theme}) => theme.space[1]};
+    }
   }
 `
 

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,0 +1,53 @@
+import styled, { DefaultTheme, keyframes } from "styled-components";
+import { SpinnerIos as Spinner } from "@styled-icons/fluentui-system-filled/SpinnerIos";
+
+type Size = 'small' | 'large' | 'xlarge';
+
+interface StyledIconWrapProps {
+  readonly size: Size;
+  readonly theme: DefaultTheme;
+}
+
+const rotate = keyframes`
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+`;
+
+const StyledIcon = styled(Spinner)<StyledIconWrapProps>`
+  animation: ${rotate} 1s linear infinite;
+  width: ${({theme, size}) => theme.iconSize[size]};
+  height: ${({theme, size}) => theme.iconSize[size]};
+`;
+
+const LoadingWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  flex-direction: column;
+`;
+
+const LoadingText = styled.p`
+  font-size: ${({theme}) => theme.fontSize.xlarge};
+  font-weight: bold;
+  margin-top: ${({theme}) => theme.space[2]};
+`
+
+export const Loading = ({size = 'small'}: { size: Size }) => { 
+
+  return (
+    <LoadingWrapper>
+      <StyledIcon size={size}/>
+      <LoadingText>
+        Carregando
+      </LoadingText>
+    </LoadingWrapper>
+  )
+}

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,7 +1,7 @@
 import styled, { DefaultTheme, keyframes } from "styled-components";
 import { SpinnerIos as Spinner } from "@styled-icons/fluentui-system-filled/SpinnerIos";
 
-type Size = 'small' | 'large' | 'xlarge';
+type Size = 'small' | 'large' | 'xlarge' | 'xxlarge';
 
 interface StyledIconWrapProps {
   readonly size: Size;

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,11 +1,10 @@
 import { useAuthState } from "react-firebase-hooks/auth";
 import { signInWithPopup } from "firebase/auth";
-import { ImGoogle2 } from 'react-icons/im';
 import styled from "styled-components";
 import { auth, authProvider } from "../firebase/clientApp";
 import { Button } from './button';
 import Image from "next/image";
-import { StyledReactIcon } from './styled-react-icon';
+import { Google } from "@styled-icons/bootstrap/Google";
 
 const NavBar = styled.nav`
   width: 100%;
@@ -50,10 +49,14 @@ export const Navigation = (props: any) => {
         <AuthAction>
           <Button onClick={
               () => {
-                signInWithPopup(auth, authProvider).then().catch(e => console.error("Erro ao fazer Login: ", error)); // TODO tratar erros (ex: sem conexão)
+                signInWithPopup(auth, authProvider)
+                  .then()
+                  .catch(
+                    e => console.error("Erro ao fazer Login: ", error)
+                  ); // TODO tratar erros (ex: sem conexão)
               }
             }>
-            <StyledReactIcon><ImGoogle2/></StyledReactIcon>&nbsp;&nbsp;Entrar com o Google
+            <Google/>Entrar com o Google
           </Button>
         </AuthAction>
       )}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import styled, { DefaultTheme } from "styled-components";
+import styled, { DefaultTheme, useTheme } from "styled-components";
 import { Collapse } from 'react-collapse';
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
@@ -82,7 +82,7 @@ const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`
 const StyledArrowIcon = styled(KeyboardArrowRight)<{ theme: DefaultTheme, isPointingDown: boolean }>`
   position: absolute;
   right: ${({theme}) => theme.space[2]};
-  width: ${({theme}) => theme.iconSize.medium};
+  width: ${({theme}) => theme.fontSize.xlarge};
   color: ${({theme}) => theme.colors.sectionSeparator};
 
   transition: all 100ms ease-in;

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -33,10 +33,15 @@ const sidebarDockButtonsProps = ({ theme }: { theme: DefaultTheme }) =>
   css`
     width: ${theme.iconSize.large};
     color: ${theme.colors.secondary};
+    border-radius: 50%;
+    background-color: ${theme.colors.secondaryOpacity015};
+    padding: ${({theme}) => theme.space[0]};
 
     &:hover {
       cursor: pointer;
       color: ${theme.colors.primary};
+      background-color: ${theme.colors.primaryOpacity01};
+      box-shadow: rgba(0, 0, 0, 0.2) -2px 2px 5px;
     }
   `
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,73 +1,60 @@
 import Link from "next/link";
-import styled from "styled-components";
+import styled, { DefaultTheme } from "styled-components";
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 
-const SidebarHeader = styled.div`
+const StyledAside = styled.aside`
+  min-width: ${({theme}) => theme.layout.sidebarWidth};
+  padding-left: ${({theme}) => theme.space[2]};
 
+  background-color: ${({theme}) => theme.colors.secondaryOpacity01};
+`;
+
+const SidebarHeader = styled.h3`
+  margin: ${({theme}) => theme.space[2]} 0;
+`;
+
+const SubMenuHeader = styled.h4`
+  padding-left: ${({theme}) => theme.space[2]};
+  margin: ${({theme}) => theme.space[1]} 0;
+`;
+
+const SubMenuList = styled.ul`
+  list-style: none;
+  padding-left: ${({theme}) => theme.space[2]};
+
+  transition: max-height .6s ease;
+  overflow: hidden;
+  max-height: 0;
+
+  &.open {
+    max-height: 400px;
+  }
 `;
 
 const SidebarContent = styled.div`
-  
 `;
 
 const Menu = styled.div`
-  
 `;
 
 const MenuItem = styled.li`
-
+  padding-bottom: ${({theme}) => theme.space[0]};
 `;
 
-const StyledAside = styled.aside`
-  width: ${({theme}) => theme.layout.sidebarWidth} !important;
-  min-width: ${({theme}) => theme.layout.sidebarWidth} !important;
-
-  &>div {
-    background-color: ${({theme}) => theme.colors.secondaryOpacity01} !important;
+const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`
+  text-decoration: none;
+  
+  &.${(props => props.activeClassName)} {
+    color: ${({theme}) => theme.colors.primary};
   }
 
-  .pro-inner-list-item {
-    background-color: ${({theme}) => theme.colors.secondaryOpacity01} !important;
+  &:hover {
+    cursor: pointer;
+    color: ${({theme}) => theme.colors.primary};
   }
-
-  .pro-item-content, .pro-menu-item .pro-inner-item {
-    font-weight: bold;
-
-    &:hover, &:active, &.active {
-      color: ${({theme}) => theme.colors.primary} !important;
-    }
-
-    &:visited {
-      color: ${({theme}) => theme.colors.text} !important;
-
-    }
-  }
-
-  .pro-item-content a {
-    color: ${({theme}) => theme.colors.text} !important;
-    &:hover {
-      color: ${({theme}) => theme.colors.primary} !important;
-    }
-  }
-
-  .pro-menu-item > .pro-inner-item:focus {
-    color: ${({theme}) => theme.colors.primary} !important;
-  }
-
-  .react-slidedown {
-    background-color: ${({theme}) => theme.colors.secondaryOpacity015} !important;
-  }
-
-  a.sidebar-item-active {
-    color: ${({theme}) => theme.colors.primary} !important;
-  }
-`;
-
-const StyledSidebarHeader = styled.h3`
-  padding-left: 20px;
-`;
+`
 
 interface SidebarProps {
   items: ContentSummary[];
@@ -76,41 +63,34 @@ interface SidebarProps {
 
 const SubMenu = ({title, children}: { title: string, children: ReactNode }) => (
   <>
-    <h3>{title}</h3>
-    <ul>
-      {/* {React.Children.map(children, (child: ReactNode) => (
-        <li>{child}</li>
-      ))} */}
+    <SubMenuHeader>{title}</SubMenuHeader>
+    <SubMenuList>
       {children}
-    </ul>
+    </SubMenuList>
   </>
 )
 
 // TODO: sidebar acessível em telas menores (https://github.com/azouaoui-med/react-pro-sidebar)
 export const Sidebar = ({title, items}: SidebarProps) => {
+  const activeClass = 'sidebar-item-active'
   const router = useRouter();
   const currentSlug = router.query.slug
 
   return (
     <StyledAside>
-      <SidebarHeader>
-        <StyledSidebarHeader>{title}</StyledSidebarHeader>
-      </SidebarHeader>
+      <SidebarHeader>{title}</SidebarHeader>
       <SidebarContent>
         <Menu>
           <SubMenu title="Módulo 4">
             <SubMenu title="Aula 3">
-              {/* <MenuItem>
-                <StyledReactIcon><GoBook/></StyledReactIcon> Aula
-              </MenuItem> */}
               {items.map(({slug, title, moduleId, classId}) => {
                 if (moduleId === '4' && classId === '3') {
                   return (
                     <MenuItem key={slug}>
                       <Link href={`/exercises/${slug}`}>
-                        <a className={slug === currentSlug ? 'sidebar-item-active' : ''}>
+                        <StyledNavLink activeClassName={activeClass} className={slug === currentSlug ? activeClass : ''}>
                           {title}
-                        </a>
+                        </StyledNavLink>
                       </Link> 
                     </MenuItem>
                   )
@@ -123,9 +103,9 @@ export const Sidebar = ({title, items}: SidebarProps) => {
                   return (
                     <MenuItem key={slug}>
                       <Link href={`/exercises/${slug}`}>
-                        <a className={slug === currentSlug ? 'sidebar-item-active' : ''}>
+                        <StyledNavLink activeClassName={activeClass}  className={slug === currentSlug ? activeClass : ''}>
                           {title}
-                        </a>
+                        </StyledNavLink>
                       </Link> 
                     </MenuItem>
                   )

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import styled, { DefaultTheme } from "styled-components";
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 
 const StyledAside = styled.aside`
   min-width: ${({theme}) => theme.layout.sidebarWidth};
@@ -15,20 +15,23 @@ const SidebarHeader = styled.h3`
   margin: ${({theme}) => theme.space[2]} 0;
 `;
 
-const SubMenuHeader = styled.h4`
+const SubMenuHeader = styled.a`
+  font-weight: bold;
   padding-left: ${({theme}) => theme.space[2]};
   margin: ${({theme}) => theme.space[1]} 0;
+  display: inline-block;
 `;
 
 const SubMenuList = styled.ul`
   list-style: none;
   padding-left: ${({theme}) => theme.space[2]};
+  margin-top: 0;
 
   transition: max-height .6s ease;
   overflow: hidden;
   max-height: 0;
 
-  &.open {
+  &.sub-menu-open {
     max-height: 400px;
   }
 `;
@@ -61,19 +64,37 @@ interface SidebarProps {
   title: string;
 }
 
-const SubMenu = ({title, children}: { title: string, children: ReactNode }) => (
-  <>
-    <SubMenuHeader>{title}</SubMenuHeader>
-    <SubMenuList>
-      {children}
-    </SubMenuList>
-  </>
-)
+const SubMenu = ({title, children}: { 
+  title: string, 
+  children: ReactNode 
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <>
+      <SubMenuHeader onClick={() => setIsOpen(!isOpen)}>{title}</SubMenuHeader>
+      <SubMenuList className={isOpen ? 'sub-menu-open' : ''}>
+        {children}
+      </SubMenuList>
+    </>
+  )
+}
+
+// interface SidebarState {
+//   [moduleId: string]: {
+//     isOpen: boolean,
+//     classes: {
+//       [classId: string]: {
+//         isOpen: boolean
+//       }
+//     }
+//   }
+// }
 
 // TODO: sidebar acessível em telas menores (https://github.com/azouaoui-med/react-pro-sidebar)
 export const Sidebar = ({title, items}: SidebarProps) => {
-  const activeClass = 'sidebar-item-active'
-  const router = useRouter();
+  const activeItemClass = 'sidebar-item-active'
+  const router = useRouter()
   const currentSlug = router.query.slug
 
   return (
@@ -88,7 +109,7 @@ export const Sidebar = ({title, items}: SidebarProps) => {
                   return (
                     <MenuItem key={slug}>
                       <Link href={`/exercises/${slug}`}>
-                        <StyledNavLink activeClassName={activeClass} className={slug === currentSlug ? activeClass : ''}>
+                        <StyledNavLink activeClassName={activeItemClass} className={slug === currentSlug ? activeItemClass : ''}>
                           {title}
                         </StyledNavLink>
                       </Link> 
@@ -103,7 +124,7 @@ export const Sidebar = ({title, items}: SidebarProps) => {
                   return (
                     <MenuItem key={slug}>
                       <Link href={`/exercises/${slug}`}>
-                        <StyledNavLink activeClassName={activeClass}  className={slug === currentSlug ? activeClass : ''}>
+                        <StyledNavLink activeClassName={activeItemClass}  className={slug === currentSlug ? activeItemClass : ''}>
                           {title}
                         </StyledNavLink>
                       </Link> 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,15 +1,24 @@
 import Link from "next/link";
-import styled, { DefaultTheme, useTheme } from "styled-components";
+import styled, { css, DefaultTheme, useTheme } from "styled-components";
 import { Collapse } from 'react-collapse';
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
 import { ReactNode, useState } from "react";
 import { KeyboardArrowRight } from "@styled-icons/material-rounded/KeyboardArrowRight"
+import {  } from "@styled-icons/fluentui-system-filled/Dock"
+import { ArrowFromRight, ArrowFromLeft } from "@styled-icons/boxicons-regular"
 
-const StyledAside = styled.aside`
-  min-width: ${({theme}) => theme.layout.sidebarWidth};
+const StyledAside = styled.aside<{ theme: DefaultTheme, isDocked: boolean }>`
+  overflow: auto;
+  position: relative;
+  z-index: 1;
+  
+  min-width: ${({theme, isDocked}) => isDocked ? theme.space[7] : theme.layout.sidebarWidth };
+  width: ${({theme, isDocked}) => isDocked ? theme.space[7] : theme.layout.sidebarWidth };
+  left: -${({theme, isDocked}) => isDocked ? theme.layout.sidebarWidth : '0px'};
 
   background-color: ${({theme}) => theme.colors.secondaryOpacity01};
+  transition: all 100ms ease-out;
 
   .ReactCollapse--collapse {
     transition: height 200ms ease-out;
@@ -18,6 +27,34 @@ const StyledAside = styled.aside`
   a {
     color: ${({theme}) => theme.colors.text}; 
   }
+`;
+
+const sidebarDockButtonsProps = ({ theme }: { theme: DefaultTheme }) =>
+  css`
+    width: ${theme.iconSize.large};
+    color: ${theme.colors.secondary};
+
+    &:hover {
+      cursor: pointer;
+      color: ${theme.colors.primary};
+    }
+  `
+
+const SidebarDockButton = styled(ArrowFromRight)`
+  ${sidebarDockButtonsProps}
+
+  position: absolute;
+  right: ${({theme}) => theme.space[2]};
+  top: ${({theme}) => theme.space[2]};
+`;
+
+const SidebarUndockButton = styled(ArrowFromLeft)`
+  ${sidebarDockButtonsProps}
+
+  position: fixed;
+  left: ${({theme}) => theme.space[4]};
+  top: ${({theme}) => theme.layout.navSize};
+  margin-top: ${({theme}) => theme.space[3]};
 `;
 
 const SidebarHeader = styled.h3`
@@ -56,6 +93,7 @@ const SubMenuList = styled.ul`
 `;
 
 const SidebarContent = styled.div`
+  padding-top: ${({theme}) => theme.space[2]};
 `;
 
 const Menu = styled.div`
@@ -68,6 +106,7 @@ const MenuItem = styled.li`
 
 const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`
   text-decoration: none;
+  font-size: ${({theme}) => theme.fontSize.medium};
   
   &.${(props => props.activeClassName)} {
     color: ${({theme}) => theme.colors.primary};
@@ -76,10 +115,11 @@ const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`
   &:hover {
     cursor: pointer;
     color: ${({theme}) => theme.colors.primary};
+    text-decoration: underline;
   }
 `
 
-const StyledArrowIcon = styled(KeyboardArrowRight)<{ theme: DefaultTheme, isPointingDown: boolean }>`
+const SubMenuArrow = styled(KeyboardArrowRight)<{ theme: DefaultTheme, isPointingDown: boolean }>`
   position: absolute;
   right: ${({theme}) => theme.space[2]};
   width: ${({theme}) => theme.fontSize.xlarge};
@@ -104,7 +144,7 @@ const SubMenu = ({title, children}: {
     <>
       <SubMenuHeader onClick={() => setIsOpened(!isOpened)}>
         {title}
-        <StyledArrowIcon isPointingDown={isOpened}></StyledArrowIcon>
+        <SubMenuArrow isPointingDown={isOpened}></SubMenuArrow>
       </SubMenuHeader>
       <Collapse isOpened={isOpened}>
         <SubMenuList>
@@ -116,13 +156,20 @@ const SubMenu = ({title, children}: {
 }
 
 export const Sidebar = ({title, items}: SidebarProps) => {
+  const [isDocked, setIsDocked] = useState<boolean>(false);
   const activeItemClass = 'sidebar-item-active'
   const router = useRouter()
   const currentSlug = router.query.slug
 
   return (
-    <StyledAside>
-      <SidebarHeader>{title}</SidebarHeader>
+    <StyledAside isDocked={isDocked}>
+      <SidebarHeader>
+        {title}
+        <SidebarDockButton onClick={() => setIsDocked(true)}></SidebarDockButton>
+        {isDocked && (
+          <SidebarUndockButton onClick={() => setIsDocked(false)}></SidebarUndockButton>
+        )}
+      </SidebarHeader>
       <SidebarContent>
         <Menu>
           <SubMenu title="Módulo 4">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -9,23 +9,31 @@ const StyledAside = styled.aside`
   min-width: ${({theme}) => theme.layout.sidebarWidth};
 
   background-color: ${({theme}) => theme.colors.secondaryOpacity01};
-  * {
-    color: ${({theme}) => theme.colors.text}; 
-  }
 
   .ReactCollapse--collapse {
     transition: height 200ms ease-out;
   }
+
+  * {
+    color: ${({theme}) => theme.colors.text}; 
+  }
 `;
 
 const SidebarHeader = styled.h3`
-  margin: ${({theme}) => theme.space[2]} 0;
+  margin: 0;
+  padding: ${({theme}) => theme.space[3]};
+  border-bottom: 1px solid ${({theme}) => theme.colors.secondaryOpacity02};
 `;
 
 const SubMenuHeader = styled.a`
+  margin: 0;
+  padding-top: ${({theme}) => theme.space[2]};
+  padding-right: 0;
+  padding-bottom: ${({theme}) => theme.space[2]};
+  padding-left: ${({theme}) => theme.space[3]};
+
   font-weight: bold;
-  margin: ${({theme}) => theme.space[1]} 0;
-  display: inline-block;
+  display: block;
   font-size: ${({theme}) => theme.fontSize.medium};
 
   &:hover {
@@ -35,9 +43,13 @@ const SubMenuHeader = styled.a`
 `;
 
 const SubMenuList = styled.ul`
+  margin: 0;
+  padding-top: ${({theme}) => theme.space[0]};
+  padding-right: 0;
+  padding-bottom: ${({theme}) => theme.space[0]};
+  padding-left: ${({theme}) => theme.space[3]};
+  
   list-style: none;
-  padding-left: ${({theme}) => theme.space[2]};
-  margin-top: 0;
   background-color: ${({theme}) => theme.colors.secondaryOpacity015};
 `;
 
@@ -49,6 +61,7 @@ const Menu = styled.div`
 
 const MenuItem = styled.li`
   padding-bottom: ${({theme}) => theme.space[0]};
+  padding-left: ${({theme}) => theme.space[3]};
 `;
 
 const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,10 +1,26 @@
 import Link from "next/link";
 import styled from "styled-components";
 import { useRouter } from "next/router";
-import { ProSidebar, Menu, MenuItem, SubMenu, SidebarHeader, SidebarContent } from 'react-pro-sidebar';
 import { ContentSummary } from "../lib/exercises";
+import React, { ReactNode } from "react";
 
-const StyledProSidebar = styled(ProSidebar)`
+const SidebarHeader = styled.div`
+
+`;
+
+const SidebarContent = styled.div`
+  
+`;
+
+const Menu = styled.div`
+  
+`;
+
+const MenuItem = styled.li`
+
+`;
+
+const StyledAside = styled.aside`
   width: ${({theme}) => theme.layout.sidebarWidth} !important;
   min-width: ${({theme}) => theme.layout.sidebarWidth} !important;
 
@@ -58,18 +74,30 @@ interface SidebarProps {
   title: string;
 }
 
+const SubMenu = ({title, children}: { title: string, children: ReactNode }) => (
+  <>
+    <h3>{title}</h3>
+    <ul>
+      {/* {React.Children.map(children, (child: ReactNode) => (
+        <li>{child}</li>
+      ))} */}
+      {children}
+    </ul>
+  </>
+)
+
 // TODO: sidebar acessível em telas menores (https://github.com/azouaoui-med/react-pro-sidebar)
 export const Sidebar = ({title, items}: SidebarProps) => {
   const router = useRouter();
   const currentSlug = router.query.slug
 
   return (
-    <StyledProSidebar>
+    <StyledAside>
       <SidebarHeader>
         <StyledSidebarHeader>{title}</StyledSidebarHeader>
       </SidebarHeader>
       <SidebarContent>
-        <Menu iconShape="square">
+        <Menu>
           <SubMenu title="Módulo 4">
             <SubMenu title="Aula 3">
               {/* <MenuItem>
@@ -107,6 +135,6 @@ export const Sidebar = ({title, items}: SidebarProps) => {
           </SubMenu>
         </Menu>
       </SidebarContent>
-    </StyledProSidebar>
+    </StyledAside>
   )
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,16 +1,20 @@
 import Link from "next/link";
 import styled, { DefaultTheme } from "styled-components";
+import { Collapse } from 'react-collapse';
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
 import { ReactNode, useState } from "react";
 
 const StyledAside = styled.aside`
   min-width: ${({theme}) => theme.layout.sidebarWidth};
-  padding-left: ${({theme}) => theme.space[2]};
 
   background-color: ${({theme}) => theme.colors.secondaryOpacity01};
   * {
     color: ${({theme}) => theme.colors.text}; 
+  }
+
+  .ReactCollapse--collapse {
+    transition: height 200ms ease-out;
   }
 `;
 
@@ -34,14 +38,7 @@ const SubMenuList = styled.ul`
   list-style: none;
   padding-left: ${({theme}) => theme.space[2]};
   margin-top: 0;
-
-  transition: max-height .6s ease;
-  overflow: hidden;
-  max-height: 0;
-
-  &.sub-menu-open {
-    max-height: 400px;
-  }
+  background-color: ${({theme}) => theme.colors.secondaryOpacity015};
 `;
 
 const SidebarContent = styled.div`
@@ -76,30 +73,20 @@ const SubMenu = ({title, children}: {
   title: string, 
   children: ReactNode 
 }) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [isOpened, setIsOpened] = useState<boolean>(false)
 
   return (
     <>
-      <SubMenuHeader onClick={() => setIsOpen(!isOpen)}>{title}</SubMenuHeader>
-      <SubMenuList className={isOpen ? 'sub-menu-open' : ''}>
-        {children}
-      </SubMenuList>
+      <SubMenuHeader onClick={() => setIsOpened(!isOpened)}>{title}</SubMenuHeader>
+      <Collapse isOpened={isOpened}>
+        <SubMenuList>
+          {children}
+        </SubMenuList>
+      </Collapse>
     </>
   )
 }
 
-// interface SidebarState {
-//   [moduleId: string]: {
-//     isOpen: boolean,
-//     classes: {
-//       [classId: string]: {
-//         isOpen: boolean
-//       }
-//     }
-//   }
-// }
-
-// TODO: sidebar acessível em telas menores (https://github.com/azouaoui-med/react-pro-sidebar)
 export const Sidebar = ({title, items}: SidebarProps) => {
   const activeItemClass = 'sidebar-item-active'
   const router = useRouter()

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -4,6 +4,7 @@ import { Collapse } from 'react-collapse';
 import { useRouter } from "next/router";
 import { ContentSummary } from "../lib/exercises";
 import { ReactNode, useState } from "react";
+import { KeyboardArrowRight } from "@styled-icons/material-rounded/KeyboardArrowRight"
 
 const StyledAside = styled.aside`
   min-width: ${({theme}) => theme.layout.sidebarWidth};
@@ -14,7 +15,7 @@ const StyledAside = styled.aside`
     transition: height 200ms ease-out;
   }
 
-  * {
+  a {
     color: ${({theme}) => theme.colors.text}; 
   }
 `;
@@ -31,6 +32,7 @@ const SubMenuHeader = styled.a`
   padding-right: 0;
   padding-bottom: ${({theme}) => theme.space[2]};
   padding-left: ${({theme}) => theme.space[3]};
+  position: relative;
 
   font-weight: bold;
   display: block;
@@ -77,6 +79,16 @@ const StyledNavLink = styled.a<{theme: DefaultTheme, activeClassName: string }>`
   }
 `
 
+const StyledArrowIcon = styled(KeyboardArrowRight)<{ theme: DefaultTheme, isPointingDown: boolean }>`
+  position: absolute;
+  right: ${({theme}) => theme.space[2]};
+  width: ${({theme}) => theme.iconSize.medium};
+  color: ${({theme}) => theme.colors.sectionSeparator};
+
+  transition: all 100ms ease-in;
+  transform: ${({isPointingDown}) => isPointingDown ? 'rotate(90deg)' : 'rotate(0deg)'};
+`;
+
 interface SidebarProps {
   items: ContentSummary[];
   title: string;
@@ -90,7 +102,10 @@ const SubMenu = ({title, children}: {
 
   return (
     <>
-      <SubMenuHeader onClick={() => setIsOpened(!isOpened)}>{title}</SubMenuHeader>
+      <SubMenuHeader onClick={() => setIsOpened(!isOpened)}>
+        {title}
+        <StyledArrowIcon isPointingDown={isOpened}></StyledArrowIcon>
+      </SubMenuHeader>
       <Collapse isOpened={isOpened}>
         <SubMenuList>
           {children}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -9,6 +9,9 @@ const StyledAside = styled.aside`
   padding-left: ${({theme}) => theme.space[2]};
 
   background-color: ${({theme}) => theme.colors.secondaryOpacity01};
+  * {
+    color: ${({theme}) => theme.colors.text}; 
+  }
 `;
 
 const SidebarHeader = styled.h3`
@@ -17,9 +20,14 @@ const SidebarHeader = styled.h3`
 
 const SubMenuHeader = styled.a`
   font-weight: bold;
-  padding-left: ${({theme}) => theme.space[2]};
   margin: ${({theme}) => theme.space[1]} 0;
   display: inline-block;
+  font-size: ${({theme}) => theme.fontSize.medium};
+
+  &:hover {
+    cursor: pointer;
+    color: ${({theme}) => theme.colors.primary};
+  }
 `;
 
 const SubMenuList = styled.ul`

--- a/components/styled-react-icon.tsx
+++ b/components/styled-react-icon.tsx
@@ -1,4 +1,4 @@
-import styled, { useTheme } from "styled-components"
+import styled, { keyframes, DefaultTheme } from "styled-components"
 
 type Size = 'small' | 'large';
 
@@ -6,21 +6,21 @@ interface StyledIconWrapProps {
   readonly size: Size;
 }
 
+const rotate = keyframes`
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+`;
+
 const StyledIconWrap = styled.span<StyledIconWrapProps>`
   top: 2px;
   position: relative;
 
-  @keyframes rotate {
-    0% {
-      transform: rotate(0);
-    }
-    100% {
-      transform: rotate(359deg);
-    }
-  }
-
-  &.rotating svg {
-    animation: rotate 0.5s linear infinite;
+  svg {
+    animation: ${rotate} 0.5s linear infinite;
   }
 
   svg {
@@ -34,7 +34,6 @@ export const StyledReactIcon = ({ children, isRotating = false, size = 'small' }
   isRotating?: boolean,
   size?: Size
  }) => {
-  const theme = useTheme();
   return (
     <StyledIconWrap className={isRotating ? "rotating" : ""} size={size}>
       {children}  

--- a/components/styled-react-icon.tsx
+++ b/components/styled-react-icon.tsx
@@ -12,10 +12,10 @@ const StyledIconWrap = styled.span<StyledIconWrapProps>`
 
   @keyframes rotate {
     0% {
-        transform: rotate(0);
+      transform: rotate(0);
     }
     100% {
-        transform: rotate(359deg);
+      transform: rotate(359deg);
     }
   }
 

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -34,35 +34,36 @@ function getExerciseMetadataBySlug(slug: string): ContentSummary {
   }
 }
 
-export function groupSummary(contentList: ContentSummary[]): ModulesGroup {
-  const group: ModulesGroup = {}
+// export function groupSummary(contentList: ContentSummary[]): ModulesGroup {
+//   const group: ModulesGroup = {}
 
-  for (let i = 0; i < contentList.length; i++){
-    const content = contentList[i];
-    const classContent = group[content.moduleId].classContentList || []
-    const exerciseContent = group[content.moduleId].exerciseContentList || []
+//   for (let i = 0; i < contentList.length; i++){
+//     const content = contentList[i];
+//     const classContent = group[content.moduleId].classContentList || []
+//     const exerciseContent = group[content.moduleId].exerciseContentList || []
 
-    if (content.type === 'aula') {
-      group[content.moduleId] = {
-        classId: content.classId,
-        classContentList: [...classContent, content],
-        exerciseContentList: [...exerciseContent, content]
-      }
-    }
-  }
+//     if (content.type === 'aula') {
+//       group[content.moduleId] = {
+//         classId: content.classId,
+//         classContentList: [...classContent, content],
+//         exerciseContentList: [...exerciseContent, content]
+//       }
+//     }
+//   }
 
-  console.log(JSON.stringify(group))
+//   console.log(JSON.stringify(group))
 
-  return group as ModulesGroup
-}
+//   return group as ModulesGroup
+// }
 
-interface ModulesGroup {
-  [key: string]: {
-    classId: string,
-    classContentList: ContentSummary[],
-    exerciseContentList: ContentSummary[]
-  }
-}
+// interface ModulesGroup {
+//   [moduleId: string]: {
+//     [classId: string]: {
+//       classContentList: ContentSummary[],
+//       exerciseContentList: ContentSummary[]
+//     }
+//   }
+// }
 
 export interface ContentSummary {
   title: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "react-firebase-hooks": "^5.0.3",
         "react-icons": "^4.4.0",
         "react-moment": "^1.1.2",
-        "react-pro-sidebar": "^0.7.1",
         "rehype-sanitize": "^5.0.1",
         "rehype-stringify": "^9.0.3",
         "remark-parse": "^10.0.1",
@@ -1198,15 +1197,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1795,11 +1785,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -4690,33 +4675,6 @@
         "react": "^16.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-pro-sidebar": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/react-pro-sidebar/-/react-pro-sidebar-0.7.1.tgz",
-      "integrity": "sha512-Iy1X8ce4t5Vqz4CsyzjwokGUE3/IObgmYzS0ins7/2eWKle0SMUPaWdgMKFIVjtVrMr5vmjPbRicq8FxnVaf8A==",
-      "dependencies": {
-        "@popperjs/core": "^2.4.0",
-        "classnames": "^2.2.6",
-        "react-slidedown": "^2.4.5",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/react-pro-sidebar/node_modules/react-slidedown": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/react-slidedown/-/react-slidedown-2.4.7.tgz",
-      "integrity": "sha512-HGDfrqo70r1WVE0DwrySPdCT27/2wcZaJYh5kOnmuPSCtjDDJrNkDdn4Ep/cma2VVfwupeAGhbc2pbrGThU6VQ==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || 17",
-        "react-dom": "^16.3.0 || 17"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -4830,11 +4788,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -6658,11 +6611,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
-    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -7107,11 +7055,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
-    },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -9148,27 +9091,6 @@
       "integrity": "sha512-lfb+shYXI2tXlQrNUpNr05/1D/kzFj8Isbfp89DQrpZk0fs2JIAnLHWETR0hQS9zvtzwLWlVv0wKLffbue5HoA==",
       "requires": {}
     },
-    "react-pro-sidebar": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/react-pro-sidebar/-/react-pro-sidebar-0.7.1.tgz",
-      "integrity": "sha512-Iy1X8ce4t5Vqz4CsyzjwokGUE3/IObgmYzS0ins7/2eWKle0SMUPaWdgMKFIVjtVrMr5vmjPbRicq8FxnVaf8A==",
-      "requires": {
-        "@popperjs/core": "^2.4.0",
-        "classnames": "^2.2.6",
-        "react-slidedown": "^2.4.5",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "dependencies": {
-        "react-slidedown": {
-          "version": "2.4.7",
-          "resolved": "https://registry.npmjs.org/react-slidedown/-/react-slidedown-2.4.7.tgz",
-          "integrity": "sha512-HGDfrqo70r1WVE0DwrySPdCT27/2wcZaJYh5kOnmuPSCtjDDJrNkDdn4Ep/cma2VVfwupeAGhbc2pbrGThU6VQ==",
-          "requires": {
-            "tslib": "^2.0.0"
-          }
-        }
-      }
-    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -9251,11 +9173,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "react-collapse": "^5.1.1",
         "react-dom": "18.2.0",
         "react-firebase-hooks": "^5.0.3",
-        "react-icons": "^4.4.0",
         "react-moment": "^1.1.2",
         "rehype-sanitize": "^5.0.1",
         "rehype-stringify": "^9.0.3",
@@ -5312,14 +5311,6 @@
         "react": ">= 16.8.0"
       }
     },
-    "node_modules/react-icons": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
-      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -10146,12 +10137,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.0.3.tgz",
       "integrity": "sha512-0+V2XwInZJNjW8B2cm+U21Hlv4xnp/1tJqIoDg2rjyWzKTQ9VoLPQ9PAt+fMqPumjLz5uCIREY7YqGSSjc439Q==",
-      "requires": {}
-    },
-    "react-icons": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
-      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
       "requires": {}
     },
     "react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
         "styled-components": "^5.1.25",
+        "styled-icons": "^10.45.0",
         "unified": "^10.1.2",
         "use-debounce": "^8.0.1"
       },
@@ -226,7 +227,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1258,6 +1258,648 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
+    },
+    "node_modules/@styled-icons/bootstrap": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.34.0.tgz",
+      "integrity": "sha512-UpzdVUR7r9BNqEfPrMchJdgMZEg9eXQxLQJUXM0ouvbI5o9j21/y1dGameO4PZtYbutT/dWv5O6y24z5JWzd5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-logos": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.38.0.tgz",
+      "integrity": "sha512-DpkUi9qV76RsyuzihQhfCho142WCxK/2oUfjcqo6BsP92qxV+4rtS5nfVsmqfnSEef4av+qSeg33fJWDyURyKg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-regular": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.38.0.tgz",
+      "integrity": "sha512-xjhafoa0/EeYtQOyTw+ohuSlBx599t8l8++JH1tQlM0l73dP4icTpF4znYL+HhZeaUe3D+UhrkfWuBBua2w2Qw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-solid": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.38.0.tgz",
+      "integrity": "sha512-uuMtF1R61smQT5r6HIYMHvpVD0XSErXXNQYl5d6lCtMyefd0gIE5Rw+iD9i/RxHFUHNHbvL69LvitCLtNWrSqw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/crypto": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.38.0.tgz",
+      "integrity": "sha512-SOfJFfofCOgExaRB0u3AA7Fdv2vbFIxtCAmyNDdjqvnTncg4HVPEg5+rysN3oHGiJBF8+uqUdtLerx3rmhYI7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/entypo": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.34.0.tgz",
+      "integrity": "sha512-9hl109HydOfi/q9ceqoI9Bmj5tv1v/RoUY2nbuGuVtKDVNCVw7WQ0eTiZkb1OgiVYsJXs6xQBcNZdVeo4en/lQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/entypo-social": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.34.0.tgz",
+      "integrity": "sha512-amhrYcc/buvTJrunRnYNeFNJ5Ru1ByV/pcICj7An9TF/NNC4exfnzaoUzOJNcMGOHU5jphrqjSosC4pQNJKqkA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-outline": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.34.0.tgz",
+      "integrity": "sha512-ONPKJO+u3DB/rsCJdIKt6OBoKBvIvM/EsulxuWniRPPr0rR5lwueGocJpJmEUi+C4gsMllBSkcL5cOdFyd1Nbw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.34.0.tgz",
+      "integrity": "sha512-74S0zzxovKTXNpID8bXB4Qy34EBq3vuVAlTd9xsT2gY16BtPH7JcGHLmtQpbpJcHuWkcQH4bSv+GLq+0/i/ljQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evil": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.34.0.tgz",
+      "integrity": "sha512-rU5MrgMow9I0Vkqo6V5WkTcj0o1toDzn8kQSQywTL1N7JuyATKZgN3kgkzNUgHd5LorcsGMetPsvDmgS31XAPw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-brands": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.38.0.tgz",
+      "integrity": "sha512-zZzGkcshXIF55geFIpMzMLH6tSPzQeeFPFZ1RMrZ3TWBjUuquMx+vYFsO7kzq939X84gLjmpkJZsAP9QKJFvMg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-regular": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.34.0.tgz",
+      "integrity": "sha512-QUqljT+uIfowGurV5GzjnHA1qvq922H+6yGRzQYBxBZ5Vgaak4Q71jtCSMqZKXcOG3tngMyhrOuaNaPOw1Q1pQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.34.0.tgz",
+      "integrity": "sha512-PnJMUPcbuPA7gswxl9FKd725qaqP5VSbmX7rk+ZZ7ivdA6Dbi1VoKYXqAc62OEisGDhzn5g56KbBvE14W1n7vw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/feather": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.34.0.tgz",
+      "integrity": "sha512-UdhKaUC8T98V5H4WEh+UBRfVT7ZTcPpgUUrXlRM2CWanuNIUKpIjj0SKhsnkuprqtzV1L6s3Koa40VTfpG9LYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-filled": {
+      "version": "10.35.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.35.0.tgz",
+      "integrity": "sha512-uupqp8u2FdnpOhVPAIAVb9Ax8p6Yu/ZDsRq3XUHhDd0e4Mb1e2KIXorwg1sRfR+PHCvWLbu6knIt17Az1OlmHQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-regular": {
+      "version": "10.35.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.35.0.tgz",
+      "integrity": "sha512-DHZRTLw6tGkmG6EOo46iHsta6xx+Gd71iHEg5GTVTsoUtk2ZFHL1GRW9KPnkcPPB6h3/QQE4c36MyHFPvPfjzA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/foundation": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.34.0.tgz",
+      "integrity": "sha512-RJksGQoStOqVQegwvtDTqrhEQjc7x5izqzBuwMw6R+18XcBC+pP8oRtuisv2ogn5icVrN/FWQHMx8EJ14jMdig==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-outline": {
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.36.0.tgz",
+      "integrity": "sha512-1IcNp8rjPetb5IMvSzCgh1/QDsz7brzMKv6AEbchByKM6oyOsv9p2PapGMRs6L5rH3LDGzouxNSYPUES8aY3Vw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-solid": {
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.36.0.tgz",
+      "integrity": "sha512-cbC0roQSwvrw+ryVx1MfK3NAxh5CyOCzJwFgwZTuXsYpk7IVNNFFSRn1uRGaFDHn3aLLEikMkxxR4q5NM07ZpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/icomoon": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.34.0.tgz",
+      "integrity": "sha512-nimtxPqlA6K2iNDeGCCYrFvPbjJl2TwM+YtX55RYC3YJFrh+MeKL+F60uvzoKWY3vZ1vsmQR3iW+aRFQHvhIOw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-outline": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.34.0.tgz",
+      "integrity": "sha512-8zLCIizxxKAA8tpJLmEnfXy+NcWW7CIxaqDQPZ/GEri4f6GA4QEf4BxCz+XXfEBoBthj+cPr/3d8oB7YygC5TQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-sharp": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.34.0.tgz",
+      "integrity": "sha512-2vmb5xa0fNDWe6QoKsfATilv9Qvlnv4z/3m1NMY+tU5ER+Z9YvPQkLcRqeS/dpm4HHfRAlGsVX5A8r8B+rPnag==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.34.0.tgz",
+      "integrity": "sha512-gp85y8VbxhBUx0xP3eokyxIkAiWkSaJO3kN1/mGfCSKcWllLBhoHikyGjWAxFPMunhzix4PM0tVudWrsSxmLeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.34.0.tgz",
+      "integrity": "sha512-BQCyzAN0RhkpI6mpIP7RvUoZOZ15d5opKfQRqQXVOfKD3Dkyi26Uog1KTuaaa/MqtqrWaYXC6Y1ypanvfpyL2g==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-outlined": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.34.0.tgz",
+      "integrity": "sha512-scn3Ih15t82rUJPI9vwnZaYL6ZiDhlYoashIJAs8c8QjJfK0rWdt+hr3E6/0wixx67BkLB3j96Jn9y+qXfVVIQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-rounded": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.34.0.tgz",
+      "integrity": "sha512-Y2QB3bz+tDmrtcgNXKIPnw8xqarObpcFxOapkP3pMDGl+guCgV5jNHrE8xTKyN5lYYQmm9oBZ5odwgT3B+Uw5g==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-sharp": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.34.0.tgz",
+      "integrity": "sha512-XY1N68Tj5TyyAHJDQwYtasKis4xuNl5xjbISdz8zreWlsY5N4nO4rh/SgAUYvblz+Xjf4P+JZAF22foVpZwIeg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-twotone": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.34.0.tgz",
+      "integrity": "sha512-o5EwR1WdjUwNebFAWqIiZwbP1ibOPy8vHX0KdkV0WDZTCXDW5Nhj3C5JeTAwPeRtFU+Bxt7NHjUmrsm3jNRzzw==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/octicons": {
+      "version": "10.44.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.44.0.tgz",
+      "integrity": "sha512-7pLWrUDkc/acwJ4ayL+Xmb7o1j5WUB6nI5dATRPzcm2CENUdEEyf17uL1J9qwB5aFoyDpo7c/UYWtq5QpGpk6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/open-iconic": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.18.0.tgz",
+      "integrity": "sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-editor": {
+      "version": "10.33.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.33.0.tgz",
+      "integrity": "sha512-V1jZ3G1J8PaBiIwf2Va7UuEXot8xR39UQ3XNIJNQClnGA04ahTsEC2mpN5pHwr4mkJijXu0Htjhnf/YiWYVsCw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-fill": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.18.0.tgz",
+      "integrity": "sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-line": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.18.0.tgz",
+      "integrity": "sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/simple-icons": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.45.0.tgz",
+      "integrity": "sha512-2agGgrxuiBjicbz5kgF1M691oNfRUYwSWy80kqJCEGXyJ9YGtLWXTSNdLYMk0Dt4JnL0/3eKItU9jYf24rCcJg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/styled-icon": "^10.6.3"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/styled-icon": {
+      "version": "10.6.3",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz",
+      "integrity": "sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@emotion/is-prop-valid": "^0.8.7"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
+      }
+    },
+    "node_modules/@styled-icons/styled-icon/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@styled-icons/styled-icon/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "node_modules/@styled-icons/typicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.18.0.tgz",
+      "integrity": "sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/zondicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.18.0.tgz",
+      "integrity": "sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.4.2",
@@ -4711,8 +5353,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -5220,6 +5861,59 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/styled-icons": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.45.0.tgz",
+      "integrity": "sha512-oUsAAr95m+IPS3JxExaxdxoVA6FIqTPEykebMe7h7rkD6X5JS5K37kg4HlWJOcpMznL0Vj3GW6S5LF1qqUwN7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/bootstrap": "10.34.0",
+        "@styled-icons/boxicons-logos": "10.38.0",
+        "@styled-icons/boxicons-regular": "10.38.0",
+        "@styled-icons/boxicons-solid": "10.38.0",
+        "@styled-icons/crypto": "10.38.0",
+        "@styled-icons/entypo": "10.34.0",
+        "@styled-icons/entypo-social": "10.34.0",
+        "@styled-icons/evaicons-outline": "10.34.0",
+        "@styled-icons/evaicons-solid": "10.34.0",
+        "@styled-icons/evil": "10.34.0",
+        "@styled-icons/fa-brands": "10.38.0",
+        "@styled-icons/fa-regular": "10.34.0",
+        "@styled-icons/fa-solid": "10.34.0",
+        "@styled-icons/feather": "10.34.0",
+        "@styled-icons/fluentui-system-filled": "10.35.0",
+        "@styled-icons/fluentui-system-regular": "10.35.0",
+        "@styled-icons/foundation": "10.34.0",
+        "@styled-icons/heroicons-outline": "10.36.0",
+        "@styled-icons/heroicons-solid": "10.36.0",
+        "@styled-icons/icomoon": "10.34.0",
+        "@styled-icons/ionicons-outline": "10.34.0",
+        "@styled-icons/ionicons-sharp": "10.34.0",
+        "@styled-icons/ionicons-solid": "10.34.0",
+        "@styled-icons/material": "10.34.0",
+        "@styled-icons/material-outlined": "10.34.0",
+        "@styled-icons/material-rounded": "10.34.0",
+        "@styled-icons/material-sharp": "10.34.0",
+        "@styled-icons/material-twotone": "10.34.0",
+        "@styled-icons/octicons": "10.44.0",
+        "@styled-icons/open-iconic": "10.18.0",
+        "@styled-icons/remix-editor": "10.33.0",
+        "@styled-icons/remix-fill": "10.18.0",
+        "@styled-icons/remix-line": "10.18.0",
+        "@styled-icons/simple-icons": "10.45.0",
+        "@styled-icons/styled-icon": "10.6.3",
+        "@styled-icons/typicons": "10.18.0",
+        "@styled-icons/zondicons": "10.18.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
       }
     },
     "node_modules/styled-jsx": {
@@ -5908,7 +6602,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -6689,6 +7382,354 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
+    },
+    "@styled-icons/bootstrap": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.34.0.tgz",
+      "integrity": "sha512-UpzdVUR7r9BNqEfPrMchJdgMZEg9eXQxLQJUXM0ouvbI5o9j21/y1dGameO4PZtYbutT/dWv5O6y24z5JWzd5w==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/boxicons-logos": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.38.0.tgz",
+      "integrity": "sha512-DpkUi9qV76RsyuzihQhfCho142WCxK/2oUfjcqo6BsP92qxV+4rtS5nfVsmqfnSEef4av+qSeg33fJWDyURyKg==",
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/boxicons-regular": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.38.0.tgz",
+      "integrity": "sha512-xjhafoa0/EeYtQOyTw+ohuSlBx599t8l8++JH1tQlM0l73dP4icTpF4znYL+HhZeaUe3D+UhrkfWuBBua2w2Qw==",
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/boxicons-solid": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.38.0.tgz",
+      "integrity": "sha512-uuMtF1R61smQT5r6HIYMHvpVD0XSErXXNQYl5d6lCtMyefd0gIE5Rw+iD9i/RxHFUHNHbvL69LvitCLtNWrSqw==",
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/crypto": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.38.0.tgz",
+      "integrity": "sha512-SOfJFfofCOgExaRB0u3AA7Fdv2vbFIxtCAmyNDdjqvnTncg4HVPEg5+rysN3oHGiJBF8+uqUdtLerx3rmhYI7g==",
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/entypo": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.34.0.tgz",
+      "integrity": "sha512-9hl109HydOfi/q9ceqoI9Bmj5tv1v/RoUY2nbuGuVtKDVNCVw7WQ0eTiZkb1OgiVYsJXs6xQBcNZdVeo4en/lQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/entypo-social": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.34.0.tgz",
+      "integrity": "sha512-amhrYcc/buvTJrunRnYNeFNJ5Ru1ByV/pcICj7An9TF/NNC4exfnzaoUzOJNcMGOHU5jphrqjSosC4pQNJKqkA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/evaicons-outline": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.34.0.tgz",
+      "integrity": "sha512-ONPKJO+u3DB/rsCJdIKt6OBoKBvIvM/EsulxuWniRPPr0rR5lwueGocJpJmEUi+C4gsMllBSkcL5cOdFyd1Nbw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/evaicons-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.34.0.tgz",
+      "integrity": "sha512-74S0zzxovKTXNpID8bXB4Qy34EBq3vuVAlTd9xsT2gY16BtPH7JcGHLmtQpbpJcHuWkcQH4bSv+GLq+0/i/ljQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/evil": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.34.0.tgz",
+      "integrity": "sha512-rU5MrgMow9I0Vkqo6V5WkTcj0o1toDzn8kQSQywTL1N7JuyATKZgN3kgkzNUgHd5LorcsGMetPsvDmgS31XAPw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/fa-brands": {
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.38.0.tgz",
+      "integrity": "sha512-zZzGkcshXIF55geFIpMzMLH6tSPzQeeFPFZ1RMrZ3TWBjUuquMx+vYFsO7kzq939X84gLjmpkJZsAP9QKJFvMg==",
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/fa-regular": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.34.0.tgz",
+      "integrity": "sha512-QUqljT+uIfowGurV5GzjnHA1qvq922H+6yGRzQYBxBZ5Vgaak4Q71jtCSMqZKXcOG3tngMyhrOuaNaPOw1Q1pQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/fa-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.34.0.tgz",
+      "integrity": "sha512-PnJMUPcbuPA7gswxl9FKd725qaqP5VSbmX7rk+ZZ7ivdA6Dbi1VoKYXqAc62OEisGDhzn5g56KbBvE14W1n7vw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/feather": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.34.0.tgz",
+      "integrity": "sha512-UdhKaUC8T98V5H4WEh+UBRfVT7ZTcPpgUUrXlRM2CWanuNIUKpIjj0SKhsnkuprqtzV1L6s3Koa40VTfpG9LYQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/fluentui-system-filled": {
+      "version": "10.35.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.35.0.tgz",
+      "integrity": "sha512-uupqp8u2FdnpOhVPAIAVb9Ax8p6Yu/ZDsRq3XUHhDd0e4Mb1e2KIXorwg1sRfR+PHCvWLbu6knIt17Az1OlmHQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/fluentui-system-regular": {
+      "version": "10.35.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.35.0.tgz",
+      "integrity": "sha512-DHZRTLw6tGkmG6EOo46iHsta6xx+Gd71iHEg5GTVTsoUtk2ZFHL1GRW9KPnkcPPB6h3/QQE4c36MyHFPvPfjzA==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/foundation": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.34.0.tgz",
+      "integrity": "sha512-RJksGQoStOqVQegwvtDTqrhEQjc7x5izqzBuwMw6R+18XcBC+pP8oRtuisv2ogn5icVrN/FWQHMx8EJ14jMdig==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/heroicons-outline": {
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.36.0.tgz",
+      "integrity": "sha512-1IcNp8rjPetb5IMvSzCgh1/QDsz7brzMKv6AEbchByKM6oyOsv9p2PapGMRs6L5rH3LDGzouxNSYPUES8aY3Vw==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/heroicons-solid": {
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.36.0.tgz",
+      "integrity": "sha512-cbC0roQSwvrw+ryVx1MfK3NAxh5CyOCzJwFgwZTuXsYpk7IVNNFFSRn1uRGaFDHn3aLLEikMkxxR4q5NM07ZpA==",
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/icomoon": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.34.0.tgz",
+      "integrity": "sha512-nimtxPqlA6K2iNDeGCCYrFvPbjJl2TwM+YtX55RYC3YJFrh+MeKL+F60uvzoKWY3vZ1vsmQR3iW+aRFQHvhIOw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/ionicons-outline": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.34.0.tgz",
+      "integrity": "sha512-8zLCIizxxKAA8tpJLmEnfXy+NcWW7CIxaqDQPZ/GEri4f6GA4QEf4BxCz+XXfEBoBthj+cPr/3d8oB7YygC5TQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/ionicons-sharp": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.34.0.tgz",
+      "integrity": "sha512-2vmb5xa0fNDWe6QoKsfATilv9Qvlnv4z/3m1NMY+tU5ER+Z9YvPQkLcRqeS/dpm4HHfRAlGsVX5A8r8B+rPnag==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/ionicons-solid": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.34.0.tgz",
+      "integrity": "sha512-gp85y8VbxhBUx0xP3eokyxIkAiWkSaJO3kN1/mGfCSKcWllLBhoHikyGjWAxFPMunhzix4PM0tVudWrsSxmLeQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/material": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.34.0.tgz",
+      "integrity": "sha512-BQCyzAN0RhkpI6mpIP7RvUoZOZ15d5opKfQRqQXVOfKD3Dkyi26Uog1KTuaaa/MqtqrWaYXC6Y1ypanvfpyL2g==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/material-outlined": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.34.0.tgz",
+      "integrity": "sha512-scn3Ih15t82rUJPI9vwnZaYL6ZiDhlYoashIJAs8c8QjJfK0rWdt+hr3E6/0wixx67BkLB3j96Jn9y+qXfVVIQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/material-rounded": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.34.0.tgz",
+      "integrity": "sha512-Y2QB3bz+tDmrtcgNXKIPnw8xqarObpcFxOapkP3pMDGl+guCgV5jNHrE8xTKyN5lYYQmm9oBZ5odwgT3B+Uw5g==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/material-sharp": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.34.0.tgz",
+      "integrity": "sha512-XY1N68Tj5TyyAHJDQwYtasKis4xuNl5xjbISdz8zreWlsY5N4nO4rh/SgAUYvblz+Xjf4P+JZAF22foVpZwIeg==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/material-twotone": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.34.0.tgz",
+      "integrity": "sha512-o5EwR1WdjUwNebFAWqIiZwbP1ibOPy8vHX0KdkV0WDZTCXDW5Nhj3C5JeTAwPeRtFU+Bxt7NHjUmrsm3jNRzzw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/octicons": {
+      "version": "10.44.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.44.0.tgz",
+      "integrity": "sha512-7pLWrUDkc/acwJ4ayL+Xmb7o1j5WUB6nI5dATRPzcm2CENUdEEyf17uL1J9qwB5aFoyDpo7c/UYWtq5QpGpk6A==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/open-iconic": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.18.0.tgz",
+      "integrity": "sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/remix-editor": {
+      "version": "10.33.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.33.0.tgz",
+      "integrity": "sha512-V1jZ3G1J8PaBiIwf2Va7UuEXot8xR39UQ3XNIJNQClnGA04ahTsEC2mpN5pHwr4mkJijXu0Htjhnf/YiWYVsCw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/remix-fill": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.18.0.tgz",
+      "integrity": "sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/remix-line": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.18.0.tgz",
+      "integrity": "sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/simple-icons": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.45.0.tgz",
+      "integrity": "sha512-2agGgrxuiBjicbz5kgF1M691oNfRUYwSWy80kqJCEGXyJ9YGtLWXTSNdLYMk0Dt4JnL0/3eKItU9jYf24rCcJg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/styled-icon": "^10.6.3"
+      }
+    },
+    "@styled-icons/styled-icon": {
+      "version": "10.6.3",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz",
+      "integrity": "sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@emotion/is-prop-valid": "^0.8.7"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+        }
+      }
+    },
+    "@styled-icons/typicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.18.0.tgz",
+      "integrity": "sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/zondicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.18.0.tgz",
+      "integrity": "sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
     },
     "@swc/helpers": {
       "version": "0.4.2",
@@ -9142,8 +10183,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -9507,6 +10547,51 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "styled-icons": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.45.0.tgz",
+      "integrity": "sha512-oUsAAr95m+IPS3JxExaxdxoVA6FIqTPEykebMe7h7rkD6X5JS5K37kg4HlWJOcpMznL0Vj3GW6S5LF1qqUwN7Q==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@styled-icons/bootstrap": "10.34.0",
+        "@styled-icons/boxicons-logos": "10.38.0",
+        "@styled-icons/boxicons-regular": "10.38.0",
+        "@styled-icons/boxicons-solid": "10.38.0",
+        "@styled-icons/crypto": "10.38.0",
+        "@styled-icons/entypo": "10.34.0",
+        "@styled-icons/entypo-social": "10.34.0",
+        "@styled-icons/evaicons-outline": "10.34.0",
+        "@styled-icons/evaicons-solid": "10.34.0",
+        "@styled-icons/evil": "10.34.0",
+        "@styled-icons/fa-brands": "10.38.0",
+        "@styled-icons/fa-regular": "10.34.0",
+        "@styled-icons/fa-solid": "10.34.0",
+        "@styled-icons/feather": "10.34.0",
+        "@styled-icons/fluentui-system-filled": "10.35.0",
+        "@styled-icons/fluentui-system-regular": "10.35.0",
+        "@styled-icons/foundation": "10.34.0",
+        "@styled-icons/heroicons-outline": "10.36.0",
+        "@styled-icons/heroicons-solid": "10.36.0",
+        "@styled-icons/icomoon": "10.34.0",
+        "@styled-icons/ionicons-outline": "10.34.0",
+        "@styled-icons/ionicons-sharp": "10.34.0",
+        "@styled-icons/ionicons-solid": "10.34.0",
+        "@styled-icons/material": "10.34.0",
+        "@styled-icons/material-outlined": "10.34.0",
+        "@styled-icons/material-rounded": "10.34.0",
+        "@styled-icons/material-sharp": "10.34.0",
+        "@styled-icons/material-twotone": "10.34.0",
+        "@styled-icons/octicons": "10.44.0",
+        "@styled-icons/open-iconic": "10.18.0",
+        "@styled-icons/remix-editor": "10.33.0",
+        "@styled-icons/remix-fill": "10.18.0",
+        "@styled-icons/remix-line": "10.18.0",
+        "@styled-icons/simple-icons": "10.45.0",
+        "@styled-icons/styled-icon": "10.6.3",
+        "@styled-icons/typicons": "10.18.0",
+        "@styled-icons/zondicons": "10.18.0"
       }
     },
     "styled-jsx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "gray-matter": "^4.0.3",
         "next": "12.2.0",
         "react": "18.2.0",
+        "react-collapse": "^5.1.1",
         "react-dom": "18.2.0",
         "react-firebase-hooks": "^5.0.3",
         "react-icons": "^4.4.0",
@@ -28,6 +29,7 @@
       "devDependencies": {
         "@types/node": "18.0.0",
         "@types/react": "18.0.14",
+        "@types/react-collapse": "^5.0.1",
         "@types/react-dom": "18.0.5",
         "@types/styled-components": "^5.1.25",
         "concurrently": "^7.3.0",
@@ -1340,6 +1342,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-collapse": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-collapse/-/react-collapse-5.0.1.tgz",
+      "integrity": "sha512-Iq3OrqvzCIP0DmAawU4T2VKH6XAplbjo/D7Qk14mcfQ92plU+OrA2SF10r2XrcFg1Wvya/5f8w1vS29RVpdoLQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -4630,6 +4641,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-collapse": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.1.tgz",
+      "integrity": "sha512-k6cd7csF1o9LBhQ4AGBIdxB60SUEUMQDAnL2z1YvYNr9KoKr+nDkhN6FK7uGaBd/rYrYfrMpzpmJEIeHRYogBw==",
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -6754,6 +6773,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-collapse": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-collapse/-/react-collapse-5.0.1.tgz",
+      "integrity": "sha512-Iq3OrqvzCIP0DmAawU4T2VKH6XAplbjo/D7Qk14mcfQ92plU+OrA2SF10r2XrcFg1Wvya/5f8w1vS29RVpdoLQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-dom": {
@@ -9057,6 +9085,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-collapse": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.1.tgz",
+      "integrity": "sha512-k6cd7csF1o9LBhQ4AGBIdxB60SUEUMQDAnL2z1YvYNr9KoKr+nDkhN6FK7uGaBd/rYrYfrMpzpmJEIeHRYogBw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gray-matter": "^4.0.3",
     "next": "12.2.0",
     "react": "18.2.0",
+    "react-collapse": "^5.1.1",
     "react-dom": "18.2.0",
     "react-firebase-hooks": "^5.0.3",
     "react-icons": "^4.4.0",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@types/node": "18.0.0",
     "@types/react": "18.0.14",
+    "@types/react-collapse": "^5.0.1",
     "@types/react-dom": "18.0.5",
     "@types/styled-components": "^5.1.25",
     "concurrently": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-firebase-hooks": "^5.0.3",
     "react-icons": "^4.4.0",
     "react-moment": "^1.1.2",
-    "react-pro-sidebar": "^0.7.1",
     "rehype-sanitize": "^5.0.1",
     "rehype-stringify": "^9.0.3",
     "remark-parse": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
     "styled-components": "^5.1.25",
+    "styled-icons": "^10.45.0",
     "unified": "^10.1.2",
     "use-debounce": "^8.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "react-collapse": "^5.1.1",
     "react-dom": "18.2.0",
     "react-firebase-hooks": "^5.0.3",
-    "react-icons": "^4.4.0",
     "react-moment": "^1.1.2",
     "rehype-sanitize": "^5.0.1",
     "rehype-stringify": "^9.0.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,8 +7,6 @@ import { Footer } from '../components/footer'
 import { Navigation } from '../components/navigation'
 import AppLayout from '../components/layout/app-layout'
 
-import 'react-pro-sidebar/dist/css/styles.css';
-
 import Moment from 'react-moment'
 import 'moment/locale/pt-br';
 Moment.globalLocale = 'pt-br';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -27,6 +27,7 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          <title>Núcleo de Tecnologia - Curso Online</title>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -27,7 +27,6 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <title>Núcleo de Tecnologia - Curso Online</title>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"

--- a/pages/exercises/[slug].tsx
+++ b/pages/exercises/[slug].tsx
@@ -22,12 +22,13 @@ const NonLoggedContentFlexWrapper = styled.div`
   justify-content: center;
 
   svg {
-    width: ${({theme}) => theme.iconSize.large}
+    width: ${({theme}) => theme.iconSize.xlarge}
   }
 `;
 
 const ContentWrapper = styled.div`
   display: grid;
+  width: 100%;
   grid-template-columns: 44% 56%;
 `
 
@@ -114,7 +115,7 @@ export default function Exercise({ title, breadcrumb, slug, content, exercisesSu
     <>
       {router.isFallback ? (
         <>
-          <Loading size="xlarge"></Loading>
+          <Loading size="xxlarge"></Loading>
         </>
       ) : (
         <ContentWrapper>
@@ -132,7 +133,7 @@ export default function Exercise({ title, breadcrumb, slug, content, exercisesSu
             </div>
           ) : (
             authLoading || uiLoading ? (
-              <Loading size="xlarge"></Loading>
+              <Loading size="xxlarge"></Loading>
             ) : (
               <NonLoggedContentFlexWrapper>
                 <div><LoginIcon /></div>  

--- a/pages/exercises/[slug].tsx
+++ b/pages/exercises/[slug].tsx
@@ -1,42 +1,34 @@
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import ErrorPage from 'next/error';
 import { useAuthState } from "react-firebase-hooks/auth";
-import { VscSignIn, VscLoading } from 'react-icons/vsc';
 import styled from 'styled-components';
-
-import { auth, db } from "../../firebase/clientApp";
-import { doc, DocumentReference, getDoc, setDoc, updateDoc } from "firebase/firestore"; 
+import { Login as LoginIcon } from "@styled-icons/heroicons-outline/Login";
 
 import { ContentSummary, getExerciseBySlug, getExercisesSlugs, getExercisesSummary } from '../../lib/exercises'
 import markdownToHtml from '../../lib/markdownToHtml'
 
+import { auth, db } from "../../firebase/clientApp";
+import { doc, DocumentReference, getDoc, setDoc, updateDoc } from "firebase/firestore"; 
+
 import { ContentDetails } from '../../components/exercise-details'
 import { ExerciseCode } from '../../components/exercise-code'
-import { Sidebar } from '../../components/sidebar'
-import { useEffect, useState } from 'react';
-import { StyledReactIcon } from '../../components/styled-react-icon';
+import { Loading } from '../../components/loading';
 
-const NonLoggedContentWrapper = styled.div`
+const NonLoggedContentFlexWrapper = styled.div`
   display: flex;
-  padding-top: ${({theme}) => theme.space[6]};
   flex-direction: column;
   text-align: center;
-`;
-
-const StyledIcon = styled(VscSignIn)`
-  width: ${({theme}) => theme.iconSize.large};
-  height: ${({theme}) => theme.iconSize.large};
-`;
-
-const LoadingWrapper = styled.div`
   justify-content: center;
-  display: flex;
-  align-items: center;
-`
 
-const ContentContainer = styled.div`
+  svg {
+    width: ${({theme}) => theme.iconSize.large}
+  }
+`;
+
+const ContentWrapper = styled.div`
   display: grid;
-  grid-template-columns: 42% 58%;
+  grid-template-columns: 44% 56%;
 `
 
 interface ExerciseProps {
@@ -122,13 +114,10 @@ export default function Exercise({ title, breadcrumb, slug, content, exercisesSu
     <>
       {router.isFallback ? (
         <>
-          <Sidebar title="Exercícios" items={exercisesSummary}></Sidebar>
-          <LoadingWrapper>
-            <StyledReactIcon isRotating size="large"><VscLoading/></StyledReactIcon>
-          </LoadingWrapper>
+          <Loading size="xlarge"></Loading>
         </>
       ) : (
-        <ContentContainer>
+        <ContentWrapper>
           <ContentDetails title={title} breadcrumb={breadcrumb} content={content} />
           {user ? (
             <div>
@@ -143,19 +132,15 @@ export default function Exercise({ title, breadcrumb, slug, content, exercisesSu
             </div>
           ) : (
             authLoading || uiLoading ? (
-              <LoadingWrapper>
-                <StyledReactIcon isRotating size="large"><VscLoading/></StyledReactIcon>
-              </LoadingWrapper>
+              <Loading size="xlarge"></Loading>
             ) : (
-              <NonLoggedContentWrapper>
-                <div>
-                  <StyledIcon />
-                </div>  
+              <NonLoggedContentFlexWrapper>
+                <div><LoginIcon /></div>  
                 <h3>Faça o Login utilizando o botão acima<br/> para abrir o editor de código</h3>
-              </NonLoggedContentWrapper>
+              </NonLoggedContentFlexWrapper>
             )
           )}
-        </ContentContainer>
+        </ContentWrapper>
       )}
     </>
   )

--- a/pages/exercises/[slug].tsx
+++ b/pages/exercises/[slug].tsx
@@ -14,6 +14,7 @@ import { doc, DocumentReference, getDoc, setDoc, updateDoc } from "firebase/fire
 import { ContentDetails } from '../../components/exercise-details'
 import { ExerciseCode } from '../../components/exercise-code'
 import { Loading } from '../../components/loading';
+import Head from 'next/head';
 
 const NonLoggedContentFlexWrapper = styled.div`
   display: flex;
@@ -113,6 +114,9 @@ export default function Exercise({ title, breadcrumb, slug, content, exercisesSu
 
   return (
     <>
+      <Head>
+        <title>Núcleo de Tecnologia - Curso Online</title>
+      </Head>
       {router.isFallback ? (
         <>
           <Loading size="xxlarge"></Loading>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from 'next';
+import Head from 'next/head';
 import styled from 'styled-components';
 
 import { getExercisesSummary } from '../lib/exercises';
@@ -22,17 +23,22 @@ const WelcomeText = styled.p`
 
 const Home: NextPage = (_props: any) => {
   return (
-    <WelcomeTextContainer>
-      <h1>Curso Online de Programação</h1>
-      <h2>Núcleo de Tecnologia - MTST</h2>
-      <WelcomeText>
-        Bem vinde ao portal do Curso Online de Programação! <br/>
-        Use o menu à esquerda para acessar os exercícios. Na <br/>
-        página do exercício é possível programar a solução <br/>
-        utilizando JavaScrpt, mas para isso é necessário fazer<br/>
-        login utilizando sua conta do Google.
-      </WelcomeText>
-    </WelcomeTextContainer>    
+    <>
+      <Head>
+        <title>Núcleo de Tecnologia - Curso Online</title>
+      </Head>
+      <WelcomeTextContainer>
+        <h1>Curso Online de Programação</h1>
+        <h2>Núcleo de Tecnologia - MTST</h2>
+        <WelcomeText>
+          Bem vinde ao portal do Curso Online de Programação! <br/>
+          Use o menu à esquerda para acessar os exercícios. Na <br/>
+          página do exercício é possível programar a solução <br/>
+          utilizando JavaScrpt, mas para isso é necessário fazer<br/>
+          login utilizando sua conta do Google.
+        </WelcomeText>
+      </WelcomeTextContainer>    
+    </>
   )
 }
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -39,8 +39,9 @@ export const theme: DefaultTheme = {
   iconSize: {
     small: '16px',
     medium: '20px',
-    large: '48px',
-    xlarge: '64px'
+    large: '32px',
+    xlarge: '48px',
+    xxlarge: '64px'
   },
   layout: {
     navSize: '8vh',

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -39,7 +39,8 @@ export const theme: DefaultTheme = {
   iconSize: {
     small: '16px',
     medium: '20px',
-    large: '48px'
+    large: '48px',
+    xlarge: '64px'
   },
   layout: {
     navSize: '8vh',

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -38,6 +38,7 @@ export const theme: DefaultTheme = {
   ],
   iconSize: {
     small: '16px',
+    medium: '20px',
     large: '48px'
   },
   layout: {

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -36,6 +36,7 @@ declare module 'styled-components' {
     space: array,
     iconSize: {
       small: string,
+      medium: string,
       large: string,
     },
     layout: {

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -38,6 +38,7 @@ declare module 'styled-components' {
       small: string,
       medium: string,
       large: string,
+      xlarge: string,
     },
     layout: {
       navSize: string,

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -39,6 +39,7 @@ declare module 'styled-components' {
       medium: string,
       large: string,
       xlarge: string,
+      xxlarge: string
     },
     layout: {
       navSize: string,


### PR DESCRIPTION
Neste PR:
- remoção da biblioteca `react-pro-sidebar`
- implementação da Sidebar utilizando `react-collapse` (uma biblioteca mais enxuta e com um suporte melhor da comunidade)
- funcionalidade de esconder e mostrar a Sidebar
- remoção da biblioteca `react-icons`
- adição da biblioteca `styled-icons` que facilita o trabalho com styled-componentes além de garantir um build otimizado com Next.js
- refatoração dos ícones para utilizar `styled-icons`
- resolvido: warning de build onde o nome da página estava sendo configurado no lugar errado